### PR TITLE
Deprecate log4go and fix gometalinter errors

### DIFF
--- a/command/execute_command.go
+++ b/command/execute_command.go
@@ -7,7 +7,7 @@ import (
 	"github.com/otoolep/rqlite/log"
 )
 
-// This command encapsulates a sqlite statement.
+// ExecuteCommand encapsulates a sqlite statement.
 type ExecuteCommand struct {
 	Stmt string `json:"stmt"`
 }
@@ -19,7 +19,7 @@ func NewExecuteCommand(stmt string) *ExecuteCommand {
 	}
 }
 
-// The name of the ExecuteCommand in the log.
+// CommandName of the ExecuteCommand in the log.
 func (c *ExecuteCommand) CommandName() string {
 	return "execute"
 }
@@ -31,7 +31,7 @@ func (c *ExecuteCommand) Apply(server raft.Server) (interface{}, error) {
 	return nil, db.Execute(c.Stmt)
 }
 
-// This command encapsulates a set of sqlite statement, which are executed
+// TransactionExecuteCommandSet encapsulates a set of sqlite statement, which are executed
 // within a transaction.
 type TransactionExecuteCommandSet struct {
 	Stmts []string `json:"stmts"`
@@ -45,7 +45,7 @@ func NewTransactionExecuteCommandSet(stmts []string) *TransactionExecuteCommandS
 	}
 }
 
-// The name of the TransactionExecute command in the log.
+// CommandName of the TransactionExecute command in the log.
 func (c *TransactionExecuteCommandSet) CommandName() string {
 	return "transaction_execute"
 }
@@ -71,6 +71,7 @@ func (c *TransactionExecuteCommandSet) Apply(server raft.Server) (interface{}, e
 		log.Errorf("Failed to start transaction: %s", err.Error())
 		return nil, err
 	}
+
 	for i := range c.Stmts {
 		err = db.Execute(c.Stmts[i])
 		if err != nil {
@@ -78,12 +79,12 @@ func (c *TransactionExecuteCommandSet) Apply(server raft.Server) (interface{}, e
 			return nil, err
 		}
 	}
-	err = db.CommitTransaction()
-	if err != nil {
+
+	if err = db.CommitTransaction(); err != nil {
 		log.Errorf("Failed to commit transaction: %s", err.Error())
 		return nil, err
-	} else {
-		commitSuccess = true
 	}
+
+	commitSuccess = true
 	return nil, nil
 }

--- a/db/db.go
+++ b/db/db.go
@@ -8,7 +8,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
-	log "code.google.com/p/log4go"
+	"github.com/otoolep/rqlite/log"
 )
 
 const (
@@ -26,17 +26,17 @@ type RowResults []map[string]string
 
 // New creates a new database. Deletes any existing database.
 func New(dbPath string) *DB {
-	log.Trace("Removing any existing SQLite database at %s", dbPath)
+	log.Tracef("Removing any existing SQLite database at %s", dbPath)
 	os.Remove(dbPath)
 	return Open(dbPath)
 }
 
 // Open an existing database, creating it if it does not exist.
 func Open(dbPath string) *DB {
-	log.Trace("Opening SQLite database path at %s", dbPath)
+	log.Tracef("Opening SQLite database path at %s", dbPath)
 	dbc, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
-		log.Error(err)
+		log.Error(err.Error())
 		return nil
 	}
 	return &DB{
@@ -53,11 +53,11 @@ func (db *DB) Close() error {
 // RowResults.
 func (db *DB) Query(query string) (RowResults, error) {
 	if !strings.HasPrefix(strings.ToUpper(query), "SELECT ") {
-		log.Warn("Query \"%s\" may modify the database", query)
+		log.Warnf("Query \"%s\" may modify the database", query)
 	}
 	rows, err := db.dbConn.Query(query)
 	if err != nil {
-		log.Error("failed to execute SQLite query", err.Error())
+		log.Errorf("failed to execute SQLite query: %s", err.Error())
 		return nil, err
 	}
 	defer rows.Close()
@@ -74,7 +74,7 @@ func (db *DB) Query(query string) (RowResults, error) {
 	for rows.Next() {
 		err = rows.Scan(dest...)
 		if err != nil {
-			log.Error("failed to scan SQLite row", err.Error())
+			log.Errorf("failed to scan SQLite row: %s", err.Error())
 			return nil, err
 		}
 
@@ -88,7 +88,7 @@ func (db *DB) Query(query string) (RowResults, error) {
 		}
 		results = append(results, r)
 	}
-	log.Debug(func() string { return "Executed query successfully: " + query })
+	log.Debugf("Executed query successfully: %s", query)
 	return results, nil
 }
 
@@ -100,7 +100,8 @@ func (db *DB) Execute(stmt string) error {
 			return fmt.Sprintf("Error executing \"%s\", error: %s", stmt, err.Error())
 		}
 		return fmt.Sprintf("Successfully executed \"%s\"", stmt)
-	})
+	}())
+
 	return err
 }
 
@@ -112,7 +113,7 @@ func (db *DB) StartTransaction() error {
 			return "Error starting transaction"
 		}
 		return "Successfully started transaction"
-	})
+	}())
 	return err
 }
 
@@ -124,7 +125,7 @@ func (db *DB) CommitTransaction() error {
 			return "Error ending transaction"
 		}
 		return "Successfully ended transaction"
-	})
+	}())
 	return err
 }
 
@@ -137,6 +138,6 @@ func (db *DB) RollbackTransaction() error {
 			return "Error rolling back transaction"
 		}
 		return "Successfully rolled back transaction"
-	})
+	}())
 	return err
 }

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -2,6 +2,7 @@ package interfaces
 
 import "github.com/rcrowley/go-metrics"
 
+// Statistics is an interface for metrics statistics
 type Statistics interface {
 	GetStatistics() (metrics.Registry, error)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,103 @@
+package log
+
+import (
+	"io"
+	"log"
+)
+
+// Log levels
+const (
+	TRACE = iota // 0
+	DEBUG = iota // 1
+	INFO  = iota // 2
+	WARN  = iota // 3
+	ERROR = iota // 4
+)
+
+// Level set for logs
+var Level = TRACE
+
+// SetLevel sets the log level
+// given a string
+func SetLevel(level string) {
+	switch level {
+	case "TRACE":
+		Level = TRACE
+	case "DEBUG":
+		Level = DEBUG
+	case "INFO":
+		Level = INFO
+	case "WARN":
+		Level = WARN
+	case "ERROR":
+		Level = ERROR
+	default:
+		Level = TRACE
+	}
+}
+
+// SetOutput set the output destination
+// of logs
+func SetOutput(w io.Writer) {
+	log.SetOutput(w)
+}
+
+// Tracef writes a formatted log on TRACE level
+func Tracef(format string, v ...interface{}) {
+	if Level <= TRACE {
+		log.Printf("[TRACE] "+format, v...)
+	}
+}
+
+// Trace writes a log on TRACE level
+func Trace(s string) {
+	Tracef(s)
+}
+
+// Debugf writes a formatted log on DEBUG level
+func Debugf(format string, v ...interface{}) {
+	if Level <= DEBUG {
+		log.Printf("[DEBUG] "+format, v...)
+	}
+}
+
+// Debug writes a log on DEBUG level
+func Debug(s string) {
+	Debugf(s)
+}
+
+// Infof writes a formatted log on INFO level
+func Infof(format string, v ...interface{}) {
+	if Level <= INFO {
+		log.Printf("[INFO ] "+format, v...)
+	}
+}
+
+// Info write a log on INFO level
+func Info(s string) {
+	Infof(s)
+}
+
+// Warnf writes a formatted log on WARN level
+func Warnf(format string, v ...interface{}) {
+	if Level <= WARN {
+		log.Printf("[WARN ] "+format, v...)
+	}
+}
+
+// Warn write a log on WARN level
+func Warn(s string) {
+	Warnf(s)
+}
+
+// Errorf writes a formatted log on ERROR level
+func Errorf(format string, v ...interface{}) {
+	if Level <= ERROR {
+		log.Printf("[ERROR] "+format, v...)
+	}
+}
+
+// Error write a log on ERROR level
+func Error(s string) {
+	Errorf(s)
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,131 @@
+package log
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type LogSuite struct{}
+
+var _ = Suite(&LogSuite{})
+
+func (s *LogSuite) TestSetLevel(c *C) {
+	SetLevel("DEBUG")
+	c.Assert(Level, Equals, DEBUG)
+
+	SetLevel("INFO")
+	c.Assert(Level, Equals, INFO)
+
+	SetLevel("WARN")
+	c.Assert(Level, Equals, WARN)
+
+	SetLevel("ERROR")
+	c.Assert(Level, Equals, ERROR)
+
+	SetLevel("TRACE")
+	c.Assert(Level, Equals, TRACE)
+}
+
+func (s *LogSuite) TestLog(c *C) {
+	logFile, err := os.OpenFile("tmptestfile.txt", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	c.Check(err, IsNil)
+	defer logFile.Close()
+	defer os.Remove("tmptestfile.txt")
+
+	SetOutput(logFile)
+
+	num, err := lineCounter(logFile)
+	c.Check(num, Equals, 0)
+	c.Check(err, IsNil)
+
+	tmpFile, _ := os.Open("tmptestfile.txt")
+	Level = ERROR
+	Trace("a")
+	Debug("a")
+	Info("a")
+	Warn("a")
+	Error("a")
+	num, err = lineCounter(tmpFile)
+	c.Check(num, Equals, 1)
+	c.Check(err, IsNil)
+	tmpFile.Close()
+
+	tmpFile, _ = os.Open("tmptestfile.txt")
+	Level = WARN
+	Trace("a")
+	Debug("a")
+	Info("a")
+	Warn("a")
+	Error("a")
+	num, err = lineCounter(tmpFile)
+	c.Check(num, Equals, 3)
+	c.Check(err, IsNil)
+	tmpFile.Close()
+
+	tmpFile, _ = os.Open("tmptestfile.txt")
+	Level = INFO
+	Trace("a")
+	Debug("a")
+	Info("a")
+	Warn("a")
+	Error("a")
+	num, err = lineCounter(tmpFile)
+	c.Check(num, Equals, 6)
+	c.Check(err, IsNil)
+	tmpFile.Close()
+
+	tmpFile, _ = os.Open("tmptestfile.txt")
+	Level = DEBUG
+	Trace("a")
+	Debug("a")
+	Info("a")
+	Warn("a")
+	Error("a")
+	num, err = lineCounter(tmpFile)
+	c.Check(num, Equals, 10)
+	c.Check(err, IsNil)
+	tmpFile.Close()
+
+	tmpFile, _ = os.Open("tmptestfile.txt")
+	Level = TRACE
+	Trace("a")
+	Debug("a")
+	Info("a")
+	Warn("a")
+	Error("a")
+	num, err = lineCounter(tmpFile)
+	c.Check(num, Equals, 15)
+	c.Check(err, IsNil)
+	tmpFile.Close()
+}
+
+// Taken from http://stackoverflow.com/a/24563853/1187471
+func lineCounter(r io.Reader) (int, error) {
+	buf := make([]byte, 8196)
+	count := 0
+	lineSep := []byte{'\n'}
+
+	for {
+		c, err := r.Read(buf)
+		if err != nil && err != io.EOF {
+			return count, err
+		}
+
+		count += bytes.Count(buf[:c], lineSep)
+
+		if err == io.EOF {
+			break
+		}
+	}
+
+	return count, nil
+}

--- a/main.go
+++ b/main.go
@@ -86,12 +86,11 @@ func main() {
 		log.Error("No data path supplied -- aborting")
 		os.Exit(1)
 	}
-	path := flag.Arg(0)
-	if err := os.MkdirAll(path, 0744); err != nil {
-		log.Errorf("Unable to create path: %s", err.Error())
-	}
 
-	s := server.NewServer(path, dbfile, snapAfter, host, port)
+	dataPath := flag.Arg(0)
+	createFile(dataPath)
+
+	s := server.NewServer(dataPath, dbfile, snapAfter, host, port)
 	go func() {
 		log.Error(s.ListenAndServe(join).Error())
 	}()
@@ -128,7 +127,7 @@ func createFile(path string) *os.File {
 	}
 
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "is a directory") {
 		log.Errorf("Unable to open file: %s", err.Error())
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -65,7 +65,11 @@ func main() {
 		}
 		defer closeFile(f)
 
-		pprof.StartCPUProfile(f)
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			log.Errorf("Unable to start CPU Profile: %s", err.Error())
+		}
+
 		defer pprof.StopCPUProfile()
 	}
 
@@ -139,6 +143,11 @@ func reportLaunch() {
 	json := fmt.Sprintf(`{"os": "%s", "arch": "%s", "app": "rqlite"}`, runtime.GOOS, runtime.GOARCH)
 	data := bytes.NewBufferString(json)
 	client := http.Client{Timeout: time.Duration(5 * time.Second)}
-	go client.Post("https://logs-01.loggly.com/inputs/8a0edd84-92ba-46e4-ada8-c529d0f105af/tag/reporting/",
-		"application/json", data)
+	go func() {
+		_, err := client.Post("https://logs-01.loggly.com/inputs/8a0edd84-92ba-46e4-ada8-c529d0f105af/tag/reporting/",
+			"application/json", data)
+		if err != nil {
+			log.Errorf("Report launch failed: %s", err.Error())
+		}
+	}()
 }

--- a/server/single_server_test.go
+++ b/server/single_server_test.go
@@ -54,7 +54,7 @@ func postEndpoint(endpoint string, body string) (*http.Response, error) {
 	return client.Do(req)
 }
 
-func isJsonBody(res *http.Response) bool {
+func isJSONBody(res *http.Response) bool {
 	b, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return false
@@ -87,17 +87,17 @@ func (s *SingleServerSuite) Test_SingleServer(c *C) {
 	res, err = getEndpoint("/statistics")
 	c.Assert(err, IsNil)
 	c.Assert(res.StatusCode, Equals, 200)
-	c.Assert(isJsonBody(res), Equals, true)
+	c.Assert(isJSONBody(res), Equals, true)
 
 	res, err = getEndpoint("/diagnostics")
 	c.Assert(err, IsNil)
 	c.Assert(res.StatusCode, Equals, 200)
-	c.Assert(isJsonBody(res), Equals, true)
+	c.Assert(isJSONBody(res), Equals, true)
 
 	res, err = getEndpoint("/raft")
 	c.Assert(err, IsNil)
 	c.Assert(res.StatusCode, Equals, 200)
-	c.Assert(isJsonBody(res), Equals, true)
+	c.Assert(isJSONBody(res), Equals, true)
 
 	// Create a database.
 	res, err = postEndpoint("/db", "CREATE TABLE foo (id integer not null primary key, name text)")
@@ -113,5 +113,5 @@ func (s *SingleServerSuite) Test_SingleServer(c *C) {
 	res, err = getEndpointBody("/db", "SELECT * from foo")
 	c.Assert(err, IsNil)
 	c.Assert(res.StatusCode, Equals, 200)
-	c.Assert(isJsonBody(res), Equals, true)
+	c.Assert(isJSONBody(res), Equals, true)
 }

--- a/server/statemachine.go
+++ b/server/statemachine.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	log "code.google.com/p/log4go"
+	"github.com/otoolep/rqlite/log"
 )
 
 type DbStateMachine struct {
@@ -17,7 +17,7 @@ func NewDbStateMachine(path string) *DbStateMachine {
 	d := &DbStateMachine{
 		dbpath: path,
 	}
-	log.Trace("New DB state machine created with path: %s", path)
+	log.Tracef("New DB state machine created with path: %s", path)
 	return d
 }
 
@@ -27,24 +27,24 @@ func NewDbStateMachine(path string) *DbStateMachine {
 // http://sqlite.org/howtocorrupt.html states it is safe to do this
 // as long as no transaction is in progress.
 func (d *DbStateMachine) Save() ([]byte, error) {
-	log.Trace("Capturing database state from path: %s", d.dbpath)
+	log.Tracef("Capturing database state from path: %s", d.dbpath)
 	b, err := ioutil.ReadFile(d.dbpath)
 	if err != nil {
-		log.Error("Failed to save state: ", err.Error())
+		log.Errorf("Failed to save state: %s", err.Error())
 		return nil, err
 	}
-	log.Trace("Database state successfully saved to %s", d.dbpath)
+	log.Tracef("Database state successfully saved to %s", d.dbpath)
 	return b, nil
 }
 
 // Recovery restores the state of the database using the given data.
 func (d *DbStateMachine) Recovery(b []byte) error {
-	log.Trace("Restoring database state to path: %s", d.dbpath)
+	log.Tracef("Restoring database state to path: %s", d.dbpath)
 	err := ioutil.WriteFile(d.dbpath, b, os.ModePerm)
 	if err != nil {
-		log.Error("Failed to recover state: ", err.Error())
+		log.Errorf("Failed to recover state: %s", err.Error())
 		return err
 	}
-	log.Trace("Database restored successfully to %s", d.dbpath)
+	log.Tracef("Database restored successfully to %s", d.dbpath)
 	return nil
 }

--- a/server/statemachine.go
+++ b/server/statemachine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/otoolep/rqlite/log"
 )
 
+// DbStateMachine contains the DB path.
 type DbStateMachine struct {
 	dbpath string
 }


### PR DESCRIPTION
Pending:
- [x] Fix gometalinter errors in `server` package (and fix #24)
- [x] Document `log` package

- ~~[ ] Normalize log messages (i.e. start all with capital letter, s/unable/failed, etc.)~~
- ~~[ ] Log to stderr when it comes to error logs (ignore if writing to log file)~~


Pull request powered by [oscillatingworks](http://oscillating.works).